### PR TITLE
fix: track created els for accurate dedupes

### DIFF
--- a/packages/schema/src/head.ts
+++ b/packages/schema/src/head.ts
@@ -93,5 +93,9 @@ export interface Unhead<Input extends {} = Head> {
    * @internal
    */
   _popSideEffectQueue: () => SideEffectsRecord
+  /**
+   * @internal
+   */
+  _elMap: Record<string, Element>
 }
 

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -39,11 +39,6 @@ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {})
 
   const head: Unhead<T> = {
     resolvedOptions: options,
-    _popSideEffectQueue() {
-      const sde = { ..._sde }
-      _sde = {}
-      return sde
-    },
     headEntries() {
       return entries
     },
@@ -103,6 +98,12 @@ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {})
       }
       await hooks.callHook('tags:resolve', resolveCtx)
       return resolveCtx.tags
+    },
+    _elMap: {},
+    _popSideEffectQueue() {
+      const sde = { ..._sde }
+      _sde = {}
+      return sde
     },
   }
 


### PR DESCRIPTION
### Description

DOM patching currently scans all nodes checking for a duplicate that it should patch instead of replacing the current. This works well for most tags but fails for any tag is key'd dynamic inner content, such as @vueuse/schema-org output.

To fix this failure and avoid scanning the DOM, we can simply track els as we create them to our dedupe key.

### Linked Issues

https://github.com/vueuse/head/issues/164


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
