### PR TITLE
fix: less aggressive innerHTML patching

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -84,7 +84,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
           $el.setAttribute(k, value)
       })
       // @todo test side effects?
-      if (TagsWithInnerContent.includes(tag.tag))
+      if (TagsWithInnerContent.includes(tag.tag) && $el.innerHTML !== (tag.children || ''))
         $el.innerHTML = tag.children || ''
     }
 

--- a/packages/schema/src/head.ts
+++ b/packages/schema/src/head.ts
@@ -93,5 +93,9 @@ export interface Unhead<Input extends {} = Head> {
    * @internal
    */
   _popSideEffectQueue: () => SideEffectsRecord
+  /**
+   * @internal
+   */
+  _elMap: Record<string, Element>
 }
 

--- a/packages/unhead/src/createHead.ts
+++ b/packages/unhead/src/createHead.ts
@@ -39,11 +39,6 @@ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {})
 
   const head: Unhead<T> = {
     resolvedOptions: options,
-    _popSideEffectQueue() {
-      const sde = { ..._sde }
-      _sde = {}
-      return sde
-    },
     headEntries() {
       return entries
     },
@@ -103,6 +98,12 @@ export function createHead<T extends {} = Head>(options: CreateHeadOptions = {})
       }
       await hooks.callHook('tags:resolve', resolveCtx)
       return resolveCtx.tags
+    },
+    _elMap: {},
+    _popSideEffectQueue() {
+      const sde = { ..._sde }
+      _sde = {}
+      return sde
     },
   }
 


### PR DESCRIPTION


### Description

Currently, innerHTML will always be patched, this isn't ideal as there's a performance cost in setting `innerHTML`. Instead we only set it if the data has actually changed

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
