### PR TITLE
fix: less aggressive innerHTML patching

### DIFF
--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -84,7 +84,7 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
           $el.setAttribute(k, value)
       })
       // @todo test side effects?
-      if (TagsWithInnerContent.includes(tag.tag))
+      if (TagsWithInnerContent.includes(tag.tag) && $el.innerHTML !== (tag.children || ''))
         $el.innerHTML = tag.children || ''
     }
 


### PR DESCRIPTION

### Description

Currently, innerHTML will always be patched, this isn't ideal as there's a performance cost in setting `innerHTML`. Instead we only set it if the data has actually changed

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
