### PR TITLE
fix: improved hash hydration logic

### DIFF
--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -1,5 +1,4 @@
-import { HasElementTags } from 'zhead'
-import { defineHeadPlugin, getActiveHead } from '..'
+import { HasElementTags, defineHeadPlugin, getActiveHead, hashCode } from '..'
 import { IsBrowser } from '../env'
 
 export const ProvideTagHashPlugin = () => {
@@ -7,16 +6,32 @@ export const ProvideTagHashPlugin = () => {
     hooks: {
       'tag:normalise': (ctx) => {
         const { tag, entry } = ctx
-        // only valid tags
-        if (!HasElementTags.includes(tag.tag))
+        const isDynamic = typeof tag.props._dynamic !== 'undefined'
+        // only valid tags with a key
+        if (!HasElementTags.includes(tag.tag) || !tag.key)
           return
+        // @ts-expect-error untyped
+        tag._hash = hashCode(JSON.stringify({ tag: tag.tag, key: tag.key }))
+
+        // ssr only from here
+        if (IsBrowser || getActiveHead()?.resolvedOptions?.document)
+          return
+
         // when we are SSR rendering tags which are server only and have a dedupe key, we need to provide a hash
         // client side should not be here if the entry is server mode (entry should be ignored)
         // if a user provides a key we will also add the hash as a way to ensure hydration works, good for
         // when SSR / CSR does not match
-        const isBrowser = IsBrowser || getActiveHead()?.resolvedOptions?.document
-        if (!isBrowser && entry._m === 'server' && tag.key)
-          tag.props['data-h-key'] = tag._d
+        if (entry._m === 'server' || isDynamic) {
+          // @ts-expect-error untyped
+          tag.props[`data-h-${tag._hash}`] = ''
+        }
+      },
+      'tags:resolve': (ctx) => {
+        // remove dynamic prop
+        ctx.tags = ctx.tags.map((t) => {
+          delete t.props._dynamic
+          return t
+        })
       },
     },
   })

--- a/packages/unhead/src/util.ts
+++ b/packages/unhead/src/util.ts
@@ -3,3 +3,22 @@ export type Arrayable<T> = T | Array<T>
 export function asArray<T>(value: Arrayable<T>): T[] {
   return Array.isArray(value) ? value : [value]
 }
+
+export function hashCode(s: string) {
+  let h = 9
+  for (let i = 0; i < s.length;)
+    h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9)
+  return ((h ^ h >>> 9) + 0x10000)
+    .toString(16)
+    .substring(1, 8)
+    .toLowerCase()
+}
+
+export const HasElementTags = [
+  'base',
+  'meta',
+  'link',
+  'style',
+  'script',
+  'noscript',
+]

--- a/packages/vue/src/utils.ts
+++ b/packages/vue/src/utils.ts
@@ -1,24 +1,30 @@
 import { resolveUnref } from '@vueuse/shared'
 import { unref } from 'vue'
+import { HasElementTags } from 'unhead'
 import type { Arrayable } from './types'
 
-export function resolveUnrefHeadInput(ref: any): any {
+export function resolveUnrefHeadInput(ref: any, lastKey: string | number = ''): any {
   const root = resolveUnref(ref)
   if (!ref || !root)
     return root
 
   if (Array.isArray(root))
-    return root.map(resolveUnrefHeadInput)
+    return root.map(r => resolveUnrefHeadInput(r, lastKey))
 
   if (typeof root === 'object') {
-    return Object.fromEntries(
+    const unrefdObj = Object.fromEntries(
       Object.entries(root).map(([key, value]) => {
         // title template and raw dom events should stay function, we support a ref'd string though
         if (key === 'titleTemplate' || key.startsWith('on'))
           return [key, unref(value)]
-        return [key, resolveUnrefHeadInput(value)]
+        return [key, resolveUnrefHeadInput(value, key)]
       }),
     )
+    // flag any tags which are dynamic
+    if (HasElementTags.includes(String(lastKey)) && JSON.stringify(unrefdObj) !== JSON.stringify(root))
+      unrefdObj._dynamic = true
+
+    return unrefdObj
   }
   return root
 }

--- a/test/unhead/e2e.test.ts
+++ b/test/unhead/e2e.test.ts
@@ -77,8 +77,8 @@ describe('unhead e2e', () => {
       <script src=\\"https://analytics.example.com/script.js\\" defer=\\"\\" async=\\"\\"></script>
       <meta property=\\"og:title\\" content=\\"My amazing site\\">
       <meta property=\\"og:description\\" content=\\"This is my amazing site\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-key=\\"meta:og:image:0\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-key=\\"meta:og:image:1\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-2983b49=\\"\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-13ea24d=\\"\\">
       <script src=\\"https://my-app.com/home.js\\"></script>
       <meta name=\\"description\\" content=\\"This is the home page\\">",
         "htmlAttrs": " lang=\\"en\\"",
@@ -116,8 +116,8 @@ describe('unhead e2e', () => {
       <script src=\\"https://analytics.example.com/script.js\\" defer=\\"\\" async=\\"\\"></script>
       <meta property=\\"og:title\\" content=\\"Home\\">
       <meta property=\\"og:description\\" content=\\"This is my amazing site\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-key=\\"meta:og:image:0\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-key=\\"meta:og:image:1\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-2983b49=\\"\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-13ea24d=\\"\\">
       <script src=\\"https://my-app.com/home.js\\"></script>
       <meta name=\\"description\\" content=\\"This is the home page\\">
       </head>

--- a/test/vue/e2e.test.ts
+++ b/test/vue/e2e.test.ts
@@ -88,8 +88,8 @@ describe('vue e2e', () => {
       <meta property=\\"og:description\\" content=\\"This is my amazing site\\">
       <meta property=\\"og:locale\\" content=\\"en_US\\">
       <meta property=\\"og:locale\\" content=\\"en_AU\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-key=\\"meta:og:image:0\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-key=\\"meta:og:image:1\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-2983b49=\\"\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-13ea24d=\\"\\">
       <script src=\\"https://my-app.com/home.js\\"></script>
       <meta name=\\"description\\" content=\\"This is the home page\\">",
         "htmlAttrs": " lang=\\"en\\"",
@@ -130,8 +130,8 @@ describe('vue e2e', () => {
       <meta property=\\"og:description\\" content=\\"This is my amazing site\\">
       <meta property=\\"og:locale\\" content=\\"en_US\\">
       <meta property=\\"og:locale\\" content=\\"en_AU\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-key=\\"meta:og:image:0\\">
-      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-key=\\"meta:og:image:1\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image.jpg\\" data-h-2983b49=\\"\\">
+      <meta property=\\"og:image\\" content=\\"https://cdn.example.com/image2.jpg\\" data-h-13ea24d=\\"\\">
       <script src=\\"https://my-app.com/home.js\\"></script>
       <meta name=\\"description\\" content=\\"This is the home page\\">
       </head>


### PR DESCRIPTION
### Description

If you have SSR and CSR input which does not match and you expect that to be the case, then it should still be able to hydrate the single DOM element rather than create duplicates (when you provide a key).

Also we want a nicer hash key, previously we just sent the key itself but this can be quite long, we want to limit it to a specific amount of characters and use the `data-h-${key}` syntax.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
