### PR TITLE
perf: improve dom patching 5x for large sets

### DIFF
--- a/examples/nuxt3/pages/benchmark/index.vue
+++ b/examples/nuxt3/pages/benchmark/index.vue
@@ -25,17 +25,17 @@ for (const i in Array.from({ length: 1000 })) {
         content: () => `${page.value.image}?${i}`,
       },
     ],
-    // script: [
-    //   {
-    //     src: () => `https://example.com/script.js?${i}`,
-    //   },
-    // ],
-    // link: [
-    //   {
-    //     as: 'style',
-    //     href: () => `https://example.com/style.js?${i}`,
-    //   },
-    // ],
+    script: [
+      {
+        src: () => `https://example.com/script.js?${i}`,
+      },
+    ],
+    link: [
+      {
+        as: 'style',
+        href: () => `https://example.com/style.js?${i}`,
+      },
+    ],
   })
 }
 const count = ref(0)

--- a/examples/nuxt3/pages/benchmark/index.vue
+++ b/examples/nuxt3/pages/benchmark/index.vue
@@ -1,16 +1,17 @@
 <script lang="ts" setup>
-import { useHead } from '#head'
+const timeTaken = ref(0)
+
 const page = ref({
   title: 'Home',
   description: 'Home page description',
-  image: 'https://nuxtjs.org/meta_400.png',
+  image: 'https://nuxtjs.org/meta_0.png',
 })
-console.time('useHead x100')
+const start = performance.now()
 useHead({
   // de-dupe keys
   title: 'bench test',
 })
-for (const i in Array.from({ length: 100 })) {
+for (const i in Array.from({ length: 1000 })) {
   useHead({
     // de-dupe keys
     title: () => `${page.value.title}-${i} | Nuxt`,
@@ -24,24 +25,27 @@ for (const i in Array.from({ length: 100 })) {
         content: () => `${page.value.image}?${i}`,
       },
     ],
-    script: [
-      {
-        src: () => `https://example.com/script.js?${i}`,
-      },
-    ],
-    link: [
-      {
-        as: 'style',
-        href: () => `https://example.com/style.js?${i}`,
-      },
-    ],
+    // script: [
+    //   {
+    //     src: () => `https://example.com/script.js?${i}`,
+    //   },
+    // ],
+    // link: [
+    //   {
+    //     as: 'style',
+    //     href: () => `https://example.com/style.js?${i}`,
+    //   },
+    // ],
   })
 }
 const count = ref(0)
-console.timeEnd('useHead x100')
+const end = performance.now()
+// round the total time as seconds
+timeTaken.value = Math.round(end - start) / 1000
 const react = () => {
   console.time('patch')
-  page.value.title = `Updated ${count.value++}`
+  page.value.image = page.value.image.replace('_' + String(count.value), '_' + String(++count.value))
+  page.value.title = `Updated ${count.value}`
   nextTick(() => {
     console.timeEnd('patch')
   })
@@ -49,10 +53,11 @@ const react = () => {
 </script>
 
 <template>
-  <div>
-    <h1>Bench test</h1>
-    <button @click="react">
-      react
-    </button>
-  </div>
+<div>
+  <h1>Bench test</h1>
+  <p>Mount: {{ timeTaken }}ms</p>
+  <button @click="react">
+    react
+  </button>
+</div>
 </template>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@antfu/eslint-config": "^0.30.1",
     "@types/fs-extra": "^9.0.13",
     "@types/jsdom": "^20.0.1",
-    "@vitest/ui": "^0.25.1",
+    "@vitest/ui": "^0.25.2",
     "@vue/server-renderer": "^3.2.45",
     "bumpp": "^8.2.1",
     "eslint": "^8.27.0",
@@ -56,7 +56,7 @@
     "typescript": "^4.8.4",
     "unbuild": "^0.9.4",
     "utility-types": "^3.10.0",
-    "vitest": "^0.25.1",
+    "vitest": "^0.25.2",
     "vue": "^3.2.45"
   },
   "resolutions": {

--- a/packages/dom/src/index.ts
+++ b/packages/dom/src/index.ts
@@ -1,1 +1,2 @@
 export * from './renderDOMHead'
+export * from './util'

--- a/packages/dom/src/renderDOMHead.ts
+++ b/packages/dom/src/renderDOMHead.ts
@@ -1,12 +1,22 @@
-import { TagsWithInnerContent, tagDedupeKey } from 'zhead'
+import { HasElementTags, tagDedupeKey } from 'zhead'
 import type {
   BeforeRenderContext,
   DomRenderTagContext,
-  HeadEntry,
   HeadTag,
   SideEffectsRecord,
   Unhead,
 } from '@unhead/schema'
+import { setAttrs } from './setAttrs'
+
+export function hashCode(s: string) {
+  let h = 9
+  for (let i = 0; i < s.length;)
+    h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9)
+  return ((h ^ h >>> 9) + 0x10000)
+    .toString(16)
+    .substring(1, 8)
+    .toLowerCase()
+}
 
 export interface RenderDomHeadOptions {
   /**
@@ -40,136 +50,131 @@ export async function renderDOMHead<T extends Unhead<any>>(head: T, options: Ren
       })
     })
 
-  const renderTag = (tag: HeadTag, entry?: HeadEntry<any>) => {
-    if (tag.tag === 'title' && tag.children) {
+  const preRenderTag = async (tag: HeadTag) => {
+    const entry = head.headEntries().find(e => e._i === tag._e)
+    const renderCtx: DomRenderTagContext = {
+      renderId: tag._d || hashCode(JSON.stringify({ ...tag, _e: undefined, _p: undefined })),
+      $el: null, shouldRender: true, tag, entry, staleSideEffects
+    }
+    await head.hooks.callHook('dom:beforeRenderTag', renderCtx)
+    return renderCtx
+  }
+
+  const renders: DomRenderTagContext[] = []
+  const pendingRenders: Record<'body' | 'head', DomRenderTagContext[]> = {
+    body: [],
+    head: [],
+  }
+
+  const markSideEffect = (ctx: DomRenderTagContext, key: string, fn: () => void) => {
+    key = `${ctx.renderId}:${key}`
+    // may not have an entry for some reason
+    if (ctx.entry)
+      ctx.entry._sde[key] = fn
+    delete staleSideEffects[key]
+  }
+  const markEl = (ctx: DomRenderTagContext) => {
+    head._elMap[ctx.renderId] = ctx.$el!
+    markSideEffect(ctx, 'el', () => {
+      ctx.$el?.remove()
+      delete head._elMap[ctx.renderId]
+    })
+  }
+
+  // first render all tags which we can match quickly
+  for (const t of await head.resolveTags()) {
+    const ctx = await preRenderTag(t)
+    if (!ctx.shouldRender)
+      continue
+    const { tag } = ctx
+    // 1. render tags which don't create a new element
+    if (tag.tag === 'title') {
       // we don't handle title side effects
-      dom.title = tag.children
-      return dom.head.querySelector('title')
+      dom.title = tag.children || ''
+      renders.push(ctx)
+      continue
     }
-
-    const tagRenderId = tag._d || tag._p!
-
-    const markSideEffect = (key: string, fn: () => void) => {
-      key = `${tagRenderId}:${key}`
-      // may not have an entry for some reason
-      if (entry)
-        entry._sde[key] = fn
-      delete staleSideEffects[key]
-    }
-
-    /**
-     * Set attributes on a DOM element, while adding entry side effects.
-     */
-    const setAttrs = ($el: Element, sideEffects = true) => {
-      // add new attributes
-      Object.entries(tag.props).forEach(([k, value]) => {
-        value = String(value)
-        const attrSdeKey = `attr:${k}`
-
-        // class attributes have their own side effects to allow for merging
-        if (k === 'class') {
-          for (const c of value.split(' ')) {
-            const classSdeKey = `${attrSdeKey}:${c}`
-            // always clear side effects
-            sideEffects && markSideEffect(classSdeKey, () => $el.classList.remove(c))
-
-            if (!$el.classList.contains(c))
-              $el.classList.add(c)
-          }
-          return
-        }
-        // always clear side effects
-        if (sideEffects && !k.startsWith('data-h-'))
-          markSideEffect(attrSdeKey, () => $el.removeAttribute(k))
-
-        if ($el.getAttribute(k) !== value)
-          $el.setAttribute(k, value)
-      })
-      // @todo test side effects?
-      if (TagsWithInnerContent.includes(tag.tag) && $el.innerHTML !== (tag.children || ''))
-        $el.innerHTML = tag.children || ''
-    }
-
     if (tag.tag === 'htmlAttrs' || tag.tag === 'bodyAttrs') {
-      const $el = dom[tag.tag === 'htmlAttrs' ? 'documentElement' : 'body']
-      setAttrs($el)
-      return $el
+      ctx.$el = dom[tag.tag === 'htmlAttrs' ? 'documentElement' : 'body']
+      setAttrs(ctx, markSideEffect)
+      renders.push(ctx)
+      continue
     }
-
-    let $newEl: Element = dom.createElement(tag.tag)
-    // don't track side effects for new elements as the element itself should be deleted
-    setAttrs($newEl, false)
-
-    // try and hydrate based on runtime mapping of created el elements
-    let $previousEl: Element | undefined = head._elMap[tagRenderId]
-    // otherwise we need to try and hydrate based on DOM state
-    const $target = dom[tag.tagPosition?.startsWith('body') ? 'body' : 'head']
+    // 2. Hydrate based on either SSR or CSR mapping
+    ctx.$el = head._elMap[ctx.renderId]
     // @ts-expect-error runtime _hash untyped
-    if (!$previousEl && tag._hash) {
+    if (!ctx.$el && tag._hash) {
       // @ts-expect-error runtime _hash untyped
-      $previousEl = $target.querySelector(`${tag.tag}[data-h-${tag._hash}]`)
+      ctx.$el = dom.querySelector(`${tag.tagPosition?.startsWith('body') ? 'body' : 'head'} > ${tag.tag}[data-h-${tag._hash}]`)
+    }
+    if (ctx.$el) {
+      markEl(ctx)
+      setAttrs(ctx)
+      renders.push(ctx)
+      continue
     }
 
-    if (!$previousEl) {
-      for (const $el of tag.tagPosition === 'bodyClose' ? [...$target.children].reverse() : $target.children) {
-        const elTag = $el.tagName.toLowerCase() as HeadTag['tag']
-        if (elTag !== tag.tag)
+    // 3. create the new dom element, we may or may not need it
+    ctx.$el = dom.createElement(tag.tag)
+    setAttrs(ctx)
+
+    pendingRenders[tag.tagPosition?.startsWith('body') ? 'body' : 'head'].push(ctx)
+  }
+
+  // 3. render tags which require a dom element to be created or requires scanning DOM to determine duplicate
+  Object.entries(pendingRenders)
+    .forEach(([pos, queue]) => {
+      if (!queue.length)
+        return
+
+      // 3a. try and find a matching existing element (we only scan the DOM once per render tree)
+      for (const $el of [...dom[pos as 'head' | 'body'].children].reverse()) {
+        const elTag = $el.tagName.toLowerCase()
+        // only valid element tags
+        if (!HasElementTags.includes(elTag))
           continue
 
-        const key = tagDedupeKey({
-          tag: elTag,
+        const dedupeKey = tagDedupeKey({
+          tag: elTag as HeadTag['tag'],
           // convert attributes to object
           props: $el.getAttributeNames()
             .reduce((props, name) => ({ ...props, [name]: $el.getAttribute(name) }), {}),
         })
-        if ((key === tag._d || $el.isEqualNode($newEl))) {
-          $previousEl = $el
-          break
+
+        const matchIdx = queue.findIndex(ctx => ctx && (ctx.tag._d === dedupeKey || $el.isEqualNode(ctx.$el!)))
+        if (matchIdx !== -1) {
+          const ctx = queue[matchIdx]
+          ctx.$el = $el
+          markEl(ctx)
+          setAttrs(ctx)
+          renders.push(ctx)
+          delete queue[matchIdx]
         }
       }
-    }
 
-    const markEl = ($el: Element) => {
-      head._elMap[tagRenderId] = $el
-      markSideEffect('el', () => {
-        $el?.remove()
-        delete head._elMap[tagRenderId]
+      // 3b. if not, create the new element
+      queue.forEach((ctx) => {
+        if (!ctx.$el)
+          return
+        switch (ctx.tag.tagPosition) {
+          case 'bodyClose':
+            dom.body.appendChild(ctx.$el)
+            break
+          case 'bodyOpen':
+            dom.body.insertBefore(ctx.$el, dom.body.firstChild)
+            break
+          case 'head':
+          default:
+            dom.head.appendChild(ctx.$el)
+            break
+        }
+        markEl(ctx)
+        renders.push(ctx)
       })
-    }
+    })
 
-    // updating an existing tag
-    if ($previousEl) {
-      markEl($previousEl)
-      setAttrs($previousEl, false)
-      return $previousEl
-    }
-
-    switch (tag.tagPosition) {
-      case 'bodyClose':
-        $newEl = dom.body.appendChild($newEl)
-        break
-      case 'bodyOpen':
-        $newEl = dom.body.insertBefore($newEl, dom.body.firstChild)
-        break
-      case 'head':
-      default:
-        $newEl = dom.head.appendChild($newEl)
-        break
-    }
-
-    markEl($newEl)
-    return $newEl
-  }
-
-  for (const tag of await head.resolveTags()) {
-    const entry = head.headEntries().find(e => e._i === tag._e)
-    const renderCtx: DomRenderTagContext = { $el: null, shouldRender: true, tag, entry, queuedSideEffects: staleSideEffects }
-    await head.hooks.callHook('dom:beforeRenderTag', renderCtx)
-    if (!renderCtx.shouldRender)
-      continue
-    renderCtx.$el = renderTag(renderCtx.tag, renderCtx.entry)
-    await head.hooks.callHook('dom:renderTag', renderCtx)
-  }
+  for (const ctx of renders)
+    await head.hooks.callHook('dom:renderTag', ctx)
 
   // clear all side effects still pending
   Object.values(staleSideEffects).forEach(fn => fn())

--- a/packages/dom/src/util.ts
+++ b/packages/dom/src/util.ts
@@ -1,0 +1,9 @@
+export function hashCode(s: string) {
+  let h = 9
+  for (let i = 0; i < s.length;)
+    h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9)
+  return ((h ^ h >>> 9) + 0x10000)
+    .toString(16)
+    .substring(1, 8)
+    .toLowerCase()
+}

--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -12,7 +12,7 @@ export interface SSRHeadPayload {
 }
 
 export interface EntryResolveCtx<T> { tags: HeadTag[]; entries: HeadEntry<T>[] }
-export interface DomRenderTagContext { $el?: Element | null; shouldRender: boolean; renderId: string, tag: HeadTag; entry?: HeadEntry<any>; staleSideEffects: SideEffectsRecord }
+export interface DomRenderTagContext { $el?: Element | null; shouldRender: boolean; renderId: string; tag: HeadTag; entry?: HeadEntry<any>; staleSideEffects: SideEffectsRecord }
 export interface BeforeRenderContext { shouldRender: boolean }
 export interface SSRRenderContext { tags: HeadTag[]; html: SSRHeadPayload }
 

--- a/packages/schema/src/hooks.ts
+++ b/packages/schema/src/hooks.ts
@@ -12,7 +12,7 @@ export interface SSRHeadPayload {
 }
 
 export interface EntryResolveCtx<T> { tags: HeadTag[]; entries: HeadEntry<T>[] }
-export interface DomRenderTagContext { $el?: Element | null; shouldRender: boolean; tag: HeadTag; entry?: HeadEntry<any>; queuedSideEffects: SideEffectsRecord }
+export interface DomRenderTagContext { $el?: Element | null; shouldRender: boolean; renderId: string, tag: HeadTag; entry?: HeadEntry<any>; staleSideEffects: SideEffectsRecord }
 export interface BeforeRenderContext { shouldRender: boolean }
 export interface SSRRenderContext { tags: HeadTag[]; html: SSRHeadPayload }
 

--- a/packages/schema/src/tags.ts
+++ b/packages/schema/src/tags.ts
@@ -22,13 +22,15 @@ export interface ResolvesDuplicates {
   tagDuplicateStrategy?: 'replace' | 'merge'
 }
 
+export type ValidTagPositions = 'head' | 'bodyClose' | 'bodyOpen'
+
 export interface TagPosition {
   /**
    * Specify where to render the tag.
    *
    * @default 'head'
    */
-  tagPosition?: 'head' | 'bodyClose' | 'bodyOpen'
+  tagPosition?: ValidTagPositions
   /**
    * Render the tag before the body close.
    *

--- a/packages/unhead/src/plugin/eventHandlersPlugin.ts
+++ b/packages/unhead/src/plugin/eventHandlersPlugin.ts
@@ -62,7 +62,7 @@ export const EventHandlersPlugin = () => {
           const sdeKey = `${ctx.tag._d || ctx.tag._p}:${k}`
           const eventName = k.slice(2).toLowerCase()
           const eventDedupeKey = `data-h-${eventName}`
-          delete ctx.queuedSideEffects[sdeKey]
+          delete ctx.staleSideEffects[sdeKey]
           if ($el!.hasAttribute(eventDedupeKey))
             return
 

--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -1,6 +1,6 @@
+import { hashCode } from '@unhead/dom'
 import { HasElementTags, defineHeadPlugin, getActiveHead } from '..'
 import { IsBrowser } from '../env'
-import { hashCode } from '@unhead/dom'
 
 export const ProvideTagHashPlugin = () => {
   return defineHeadPlugin({

--- a/packages/unhead/src/plugin/provideTagHashPlugin.ts
+++ b/packages/unhead/src/plugin/provideTagHashPlugin.ts
@@ -1,5 +1,6 @@
-import { HasElementTags, defineHeadPlugin, getActiveHead, hashCode } from '..'
+import { HasElementTags, defineHeadPlugin, getActiveHead } from '..'
 import { IsBrowser } from '../env'
+import { hashCode } from '@unhead/dom'
 
 export const ProvideTagHashPlugin = () => {
   return defineHeadPlugin({

--- a/packages/unhead/src/util.ts
+++ b/packages/unhead/src/util.ts
@@ -4,16 +4,6 @@ export function asArray<T>(value: Arrayable<T>): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-export function hashCode(s: string) {
-  let h = 9
-  for (let i = 0; i < s.length;)
-    h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9)
-  return ((h ^ h >>> 9) + 0x10000)
-    .toString(16)
-    .substring(1, 8)
-    .toLowerCase()
-}
-
 export const HasElementTags = [
   'base',
   'meta',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
       '@antfu/eslint-config': ^0.30.1
       '@types/fs-extra': ^9.0.13
       '@types/jsdom': ^20.0.1
-      '@vitest/ui': ^0.25.1
+      '@vitest/ui': ^0.25.2
       '@vue/server-renderer': ^3.2.45
       '@zhead/schema': 1.0.0-beta.13
       bumpp: ^8.2.1
@@ -21,7 +21,7 @@ importers:
       unbuild: ^0.9.4
       unplugin-auto-import: ^0.11.4
       utility-types: ^3.10.0
-      vitest: ^0.25.1
+      vitest: ^0.25.2
       vue: ^3.2.45
     dependencies:
       '@zhead/schema': 1.0.0-beta.13
@@ -30,7 +30,7 @@ importers:
       '@antfu/eslint-config': 0.30.1_rmayb2veg2btbq6mbmnyivgasy
       '@types/fs-extra': 9.0.13
       '@types/jsdom': 20.0.1
-      '@vitest/ui': 0.25.1
+      '@vitest/ui': 0.25.2
       '@vue/server-renderer': 3.2.45_vue@3.2.45
       bumpp: 8.2.1
       eslint: 8.27.0
@@ -39,7 +39,7 @@ importers:
       typescript: 4.8.4
       unbuild: 0.9.4
       utility-types: 3.10.0
-      vitest: 0.25.1_oullksb5ic6y72oh2wekoaiuii
+      vitest: 0.25.2_cy5vuarmyj5wpd5s3xpvbmxp5u
       vue: 3.2.45
 
   examples/nuxt3:
@@ -2662,8 +2662,8 @@ packages:
       vue: 3.2.45
     dev: true
 
-  /@vitest/ui/0.25.1:
-    resolution: {integrity: sha512-VjzyfLjNS5Zc7XCCFJW3cM2iVW305D65NG0PIWefA4A8mwOH/QJJ4nFj/4cwXzwL0/VT3/ppvpv3UDNZoh/YOQ==}
+  /@vitest/ui/0.25.2:
+    resolution: {integrity: sha512-/pUR88zjiF/5qnzb8Ou9i3+NDgteMcqk7G8VZox/qzcs7Z06dLpNzAxANOANP9m8U/yrJtPNjQqeuMI26HbWwA==}
     dependencies:
       sirv: 2.0.2
     dev: true
@@ -11306,15 +11306,15 @@ packages:
     dependencies:
       '@types/node': 18.11.9
       esbuild: 0.15.13
-      postcss: 8.4.18
+      postcss: 8.4.19
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.25.1_oullksb5ic6y72oh2wekoaiuii:
-    resolution: {integrity: sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==}
+  /vitest/0.25.2_cy5vuarmyj5wpd5s3xpvbmxp5u:
+    resolution: {integrity: sha512-qqkzfzglEFbQY7IGkgSJkdOhoqHjwAao/OrphnHboeYHC5JzsVFoLCaB2lnAy8krhj7sbrFTVRApzpkTOeuDWQ==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
@@ -11338,7 +11338,7 @@ packages:
       '@types/chai': 4.3.4
       '@types/chai-subset': 1.3.3
       '@types/node': 18.11.9
-      '@vitest/ui': 0.25.1
+      '@vitest/ui': 0.25.2
       acorn: 8.8.1
       acorn-walk: 8.2.0
       chai: 4.3.7

--- a/test/unhead/resolveTags.test.ts
+++ b/test/unhead/resolveTags.test.ts
@@ -199,8 +199,8 @@ describe('resolveTags', () => {
       [
         {
           "_d": "charset",
-          "_e": 1,
-          "_p": 1027,
+          "_e": 0,
+          "_p": 3,
           "props": {
             "charset": "utf-8",
           },
@@ -208,8 +208,8 @@ describe('resolveTags', () => {
         },
         {
           "_d": "htmlAttrs",
-          "_e": 1,
-          "_p": 1024,
+          "_e": 0,
+          "_p": 0,
           "props": {
             "dir": "ltr",
             "lang": "en",
@@ -218,24 +218,24 @@ describe('resolveTags', () => {
         },
         {
           "_d": "bodyAttrs",
-          "_e": 1,
-          "_p": 1025,
+          "_e": 0,
+          "_p": 1,
           "props": {
             "class": "dark",
           },
           "tag": "bodyAttrs",
         },
         {
-          "_e": 1,
-          "_p": 1026,
+          "_e": 0,
+          "_p": 2,
           "props": {
             "src": "https://cdn.example.com/script2.js",
           },
           "tag": "script",
         },
         {
-          "_e": 1,
-          "_p": 1028,
+          "_e": 0,
+          "_p": 4,
           "props": {
             "href": "https://cdn.example.com/favicon.ico",
             "rel": "icon",


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Numerous changes to the DOM patching logic:
- avoid iterating dom tree for each tag, instead iterate it once for all pending renders
- use a more appropriate render key if no dedupe key is provided (now a hash of the tag)
- avoid checking to patch attributes of dom elements which we know haven't changed
- keep entry patching within the same entry 

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
